### PR TITLE
Fix Java modules cannot depend on Android modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ selendroid.iws
 gradle/
 gradlew
 gradlew.bat
+
+build/

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,7 @@ selendroid.ipr
 selendroid.iws
 .idea/
 *.iml
+
+gradle/
+gradlew
+gradlew.bat

--- a/selendroid-standalone/build.gradle
+++ b/selendroid-standalone/build.gradle
@@ -15,8 +15,6 @@ apply plugin: 'application'
 dependencies {
     compile project(':selendroid-common')
     compile project(':selendroid-server-common')
-    compile project(':selendroid-server')
-    compile project(':android-driver-app')
     compile 'org.apache.httpcomponents:httpclient:4.3.4'
     compile 'org.json:json:20090211'
     compile 'commons-io:commons-io:2.2'

--- a/selendroid-test-app/build.gradle
+++ b/selendroid-test-app/build.gradle
@@ -3,42 +3,41 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.3.0'
+        // https://bintray.com/android/android-tools/com.android.tools.build.gradle/view
+        classpath 'com.android.tools.build:gradle:1.4.0-beta4'
     }
 }
 repositories {
     jcenter()
 }
-apply plugin: 'com.android.library'
+
+apply plugin: 'com.android.application'
 
 dependencies {
-    compile group: 'commons-io', name: 'commons-io', version:'2.2'
-    compile group: 'commons-logging', name: 'commons-logging', version:'1.1.2'
-    compile group: 'org.json', name: 'json', version:'20090211'
-    compile group: 'net.sf.saxon', name: 'Saxon-HE', version:'9.4.0.6'
-    compile group: 'dom4j', name: 'dom4j', version:'1.6.1'
-    compile group: 'xml-apis', name: 'xml-apis', version:'1.4.01'
-    compile group: 'org.apache.httpcomponents', name: 'httpclient', version:'4.3.4'
-    compile "junit:junit:4.8.2"
-    compile group: 'org.hamcrest', name: 'hamcrest-all', version:'1.3'
-    compile group: 'org.mockito', name: 'mockito-all', version:'1.9.5'
-    compile group: 'com.google.android', name: 'android', version:'2.3.3'
+    testCompile 'junit:junit:4.8.2'
+    testCompile 'org.hamcrest:hamcrest-all:1.3'
+    testCompile 'org.mockito:mockito-all:1.9.5'
 
-    compile files('../third-party/cordova-3.7.0/classes.jar')
-    compile files('../third-party/cordova-4.0.0/classes.jar')
-    compile files('../third-party/support-v4/classes.jar')
-    compile project(':selendroid-standalone')
-    compile project(':selendroid-client')
-    compile project(':selendroid-server-common')
+    compile 'com.android.support:support-v4:23.0.1'
 }
 
 android {
-    compileSdkVersion 21
-    buildToolsVersion "21.1.2"
+    compileSdkVersion 23
+    buildToolsVersion "23.0.1" // https://developer.android.com/tools/revisions/build-tools.html
 
     defaultConfig {
         minSdkVersion 10
         targetSdkVersion 16
+    }
+
+    adbOptions {
+        timeOutInMs 60 * 1000
+    }
+
+    // Selendroid uses Java 1.6
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_6
+        targetCompatibility JavaVersion.VERSION_1_6
     }
 
     sourceSets {


### PR DESCRIPTION
Only the APK files from selendroid-server and android-driver-app are required by selendroid-standalone.

Warning:Ignoring dependency of module 'selendroid-server' on module 'selendroid-standalone'. Java modules cannot depend on Android modules
Warning:Ignoring dependency of module 'android-driver-app' on module 'selendroid-standalone'. Java modules cannot depend on Android modules
